### PR TITLE
Added additional pie chart/label functionality 

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -105,11 +105,31 @@ Raphael.fn.g.piechart = function (cx, cy, r, values, opts) {
                     total: total,
                     label: that.labels && that.labels[j]
                 };
-                cover.mouseover(function () {
-                    fin.call(o);
-                }).mouseout(function () {
-                    fout.call(o);
-                });
+
+                // Hover modes:
+                // 0 : Callbacks NOT triggered on hover
+                // 1 : Callbacks triggered on hover over SECTOR ONLY
+                // 2 : Callbacks triggered on hover over BOTH LABEL AND SECTOR
+                // 3 : Callbacks triggered on hover over LABEL ONLY
+                if (typeof(opts.hovermode) === 'undefined') 
+                	opts.hovermode = 1; // for backwards compatibility
+                
+                if (opts.hovermode && opts.hovermode < 3) {
+                    cover.mouseover(function () {
+                        fin.call(o);
+                    }).mouseout(function () {
+                        fout.call(o);
+                    });
+                }
+                    
+                if (opts.hovermode && opts.hovermode > 1) {
+                    that.labels[j].mouseover(function () {
+                        fin.call(o);
+                    }).mouseout(function () {
+                        fout.call(o);
+                    });
+                }
+
             })(series[i], covers[i], i);
         }
         return this;


### PR DESCRIPTION
Hi Dmitry, I added an instance option called "hovermode" and set it to be backwards compatible. I was frustrated that hovering over pie sectors triggered a callback on the labels (they got bigger, etc.), but hovering over the labels did not show the corresponding sectors. This commit would add four possible hovermodes, with the default being set to the CURRENT BEHAVIOR if left undefined:

Hovermode = 0, Callbacks NOT triggered ever
Hovermode = 1, CURRENT BEHAVIOR, Callbacks triggered on hover over sectors ONLY
Hovermode = 2, Callbacks triggered on hover over sectors AND labels
Hovermode = 3, Callbacks triggered on hover over labels ONLY

Please keep in mind that this is fully backwards compatible, but only adds new functionality for those that configure a certain hovermode during g.pie instantiation.

Best, Dakota
