### PR TITLE
2-area Venn diagrams

### DIFF
--- a/g.sunburst.js
+++ b/g.sunburst.js
@@ -99,7 +99,7 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 			endAngle = prevAngle,
 			children = data.children,
 			childIdx = 0;
-		for (var i in children) {
+		for (var i = 0; i < children.length; i++) {
 			startAngle = endAngle;
 			endAngle += children[i].value / total * 360;
 

--- a/g.sunburst.js
+++ b/g.sunburst.js
@@ -69,7 +69,7 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 	function getDataSeriesFromObj(rootLabel, values) {
 		var res = {label: rootLabel, value: 0, children: []},
 		    maxDepth = 0;
-		for (var i = 0; i < values.length; i++) {
+		for (var i in values) {
 			var child;
 			if (~~values[i]) {
 				res.value += values[i];

--- a/g.sunburst.js
+++ b/g.sunburst.js
@@ -1,0 +1,160 @@
+/*!
+ * g.sunburst 0.1 - Sunburst diagrams
+ * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël 
+ *
+ * Copyright (c)2010 zynamics GmbH (http://zynamics.com)
+ * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+ * license.
+ *
+ * Author: Christian Blichmann <christian.blichmann@zynamics.com>
+ */
+Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
+	opts = opts || {};
+	var paper = this,
+		chart = this.set(),
+		series = this.set(),
+		levelRadii = [];
+
+	function levelRadius(level) {
+		if (levelRadii[level])
+			return levelRadii[level];
+
+		var levelWidth = opts.onLevelWidth || function(level) {
+				return this.levelWidths ? this.levelWidths[level] :
+					(this.levelWidth || 50);
+			},
+			res = 0;
+
+		for (var i = 0; i <= level; i++)
+			res += levelWidth.call(opts, i);
+
+		levelRadii[level] = res;
+		return res;
+	}
+
+    function sector(cx, cy, ri, ro, startAngle, endAngle, params) {
+		var large = Math.abs(endAngle - startAngle) > 180,
+			rad = Math.PI / 180,
+		    xo1 = cx + ro * Math.cos(-startAngle * rad),
+		    yo1 = cy + ro * Math.sin(-startAngle * rad),
+		    xo2 = cx + ro * Math.cos(-endAngle * rad),
+		    yo2 = cy + ro * Math.sin(-endAngle * rad),
+		    xi1 = cx + ri * Math.cos(-startAngle * rad),
+		    yi1 = cy + ri * Math.sin(-startAngle * rad),
+		    xi2 = cx + ri * Math.cos(-endAngle * rad),
+		    yi2 = cy + ri * Math.sin(-endAngle * rad),
+		    halfAngle = Math.abs(endAngle + startAngle) / 2,
+		    rm = (ro + ri) / 2,
+		    xm = cx + rm * Math.cos(-halfAngle * rad),
+		    ym = cy + rm * Math.sin(-halfAngle * rad),
+		    res = paper.path([
+				"M", xi1, yi1,
+				"A", ri, ri, 0, +large, 0, xi2, yi2,
+				"L", xo2, yo2,
+				"A", ro, ro, 0, +large, 1, xo1, yo1,
+				"Z",
+			]);
+		res.middle = {x: xm, y: ym};
+		res.mangle = halfAngle;
+		res.ri = ri;
+		res.ro = ro;
+		return res.attr(params);
+	}
+
+	function getDataSeriesFromObj(rootLabel, values) {
+		var res = {label: rootLabel, value: 0, children: []},
+			maxDepth = 0;
+		for (var i in values) {
+			var child;
+			if (~~values[i]) {
+				res.value += values[i];
+				child = {label: i, value: values[i], depth: 0, children: []};
+			} else {
+				child = getDataSeriesFromObj(i, values[i]);
+				res.value += child.value;
+			}
+			maxDepth = Math.max(maxDepth, child.depth);
+			res.children[res.children.length] = child;
+		}
+		res.depth = maxDepth + 1;
+		return res;
+	}
+
+	function colorAttr(idx, depth) {
+		var idx = idx % (opts.colors.length || opts.gradients.length);
+
+		if (opts.onGradient)
+			return {gradient: opts.onGradient.call(opts, idx, depth)};
+
+		return opts.gradients ? {gradient: opts.gradients[idx]} : {
+			fill: opts.colors ? opts.colors[idx] : Raphael.getColor()};
+	}
+
+	function renderSeries(data, renderTo, level, total, prevAngle, parentIdx) {
+		level = level || 0;
+		total = total || data.value;
+		prevAngle = prevAngle || (opts.offsetAngle || 0);
+		parentIdx = parentIdx || 0;
+		var startAngle,
+			endAngle = prevAngle,
+			children = data.children,
+			childIdx = 0;
+		for (var i in children) {
+			startAngle = endAngle;
+			endAngle += children[i].value / total * 360;
+
+			var thisIdx = level == 0 ? childIdx : parentIdx,
+				sect = sector(cx, cy, levelRadius(level), levelRadius(level + 1),
+					startAngle, endAngle,
+					colorAttr(!opts.colorizeByLevel ? thisIdx : level, level)).attr({
+						stroke: opts.stroke || "#fff",
+						"stroke-width": opts.strokewidth || 1});
+			sect.level = level;
+			sect.value = children[i].value;
+			sect.label = children[i].label;
+			renderTo.push(sect);
+			renderSeries(children[i], renderTo, level + 1, total, startAngle,
+				thisIdx);
+			childIdx++;
+		}
+	}
+
+	Raphael.getColor.reset();
+	data = getDataSeriesFromObj(opts.rootLabel, values);
+	renderSeries(data, series);
+
+	function getCallbackContext(sector) {
+		return {
+			sector: sector,
+			cx: cx,
+			cy: cy,
+            mx: sector.middle.x,
+            my: sector.middle.y,
+            mangle: sector.mangle
+		};
+	}
+
+    chart.hover = function(fin, fout) {
+        fout = fout || function () {};
+        for (var i = 0; i < series.length; i++)
+            (function (sector) {
+                var o = getCallbackContext(sector);
+                sector.mouseover(function () { fin.call(o); });
+                sector.mouseout(function () { fout.call(o); });
+            })(series[i]);
+        return this;
+    };
+
+    chart.click = function(f) {
+        for (var i = 0; i < series.length; i++)
+            (function (sector) {
+                var o = getCallbackContext(sector);
+                sector.click(function () { f.call(o); });
+            })(series[i]);
+        return this;
+    };
+
+    chart.push(series);
+    chart.series = series;
+    return chart;
+};

--- a/g.sunburst.js
+++ b/g.sunburst.js
@@ -1,8 +1,8 @@
 /*!
  * g.sunburst 0.1 - Sunburst diagrams
- * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël 
+ * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël
  *
- * Copyright (c)2010 zynamics GmbH (http://zynamics.com)
+ * Copyright (c)2011 zynamics GmbH (http://zynamics.com)
  * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * license.
  *
@@ -33,8 +33,8 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 	}
 
 	function sector(cx, cy, ri, ro, startAngle, endAngle, params) {
-		var sliceAngle = endAngle - startAngle;
-		var full = Math.abs(sliceAngle) >= 360;
+		var sliceAngle = endAngle - startAngle,
+		    full = Math.abs(sliceAngle) >= 360;
 		if (full)
 			endAngle = startAngle + 359.99;
 
@@ -68,9 +68,9 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 
 	function getDataSeriesFromObj(rootLabel, values) {
 		var res = {label: rootLabel, value: 0, children: []},
-		    maxDepth = 0;
+		    maxDepth = 0,
+		    child;
 		for (var i in values) {
-			var child;
 			if (~~values[i]) {
 				res.value += values[i];
 				child = {label: i, value: values[i], depth: 0, children: []};
@@ -109,9 +109,9 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 			endAngle += children[i].value / total * 360;
 
 			var thisIdx = level == 0 ? childIdx : parentIdx,
-				sect = sector(cx, cy, levelRadius(level), levelRadius(level + 1),
-					startAngle, endAngle,
-					colorAttr(!opts.colorizeByLevel ? thisIdx : level, level)).attr({
+			    sect = sector(cx, cy, levelRadius(level), levelRadius(level + 1),
+			    startAngle, endAngle,
+			    colorAttr(!opts.colorizeByLevel ? thisIdx : level, level)).attr({
 						stroke: opts.stroke || "#fff",
 						"stroke-width": opts.strokewidth || 1});
 			sect.level = level;
@@ -125,7 +125,7 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 	}
 
 	Raphael.getColor.reset();
-	data = getDataSeriesFromObj(opts.rootLabel, values);
+	var data = getDataSeriesFromObj(opts.rootLabel, values);
 	renderSeries(data, series);
 
 	function getCallbackContext(sector) {
@@ -159,6 +159,7 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 		return this;
 	};
 
+	// TODO: Need access functions for individual rings, sectors and items
 	chart.push(series);
 	chart.series = series;
 	return chart;

--- a/g.sunburst.js
+++ b/g.sunburst.js
@@ -11,9 +11,9 @@
 Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 	opts = opts || {};
 	var paper = this,
-		chart = this.set(),
-		series = this.set(),
-		levelRadii = [];
+	    chart = this.set(),
+	    series = this.set(),
+	    levelRadii = [];
 
 	function levelRadius(level) {
 		if (levelRadii[level])
@@ -32,9 +32,14 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 		return res;
 	}
 
-    function sector(cx, cy, ri, ro, startAngle, endAngle, params) {
-		var large = Math.abs(endAngle - startAngle) > 180,
-			rad = Math.PI / 180,
+	function sector(cx, cy, ri, ro, startAngle, endAngle, params) {
+		var sliceAngle = endAngle - startAngle;
+		var full = Math.abs(sliceAngle) >= 360;
+		if (full)
+			endAngle = startAngle + 359.99;
+
+		var large = Math.abs(sliceAngle) > 180,
+		    rad = Math.PI / 180,
 		    xo1 = cx + ro * Math.cos(-startAngle * rad),
 		    yo1 = cy + ro * Math.sin(-startAngle * rad),
 		    xo2 = cx + ro * Math.cos(-endAngle * rad),
@@ -50,9 +55,9 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 		    res = paper.path([
 				"M", xi1, yi1,
 				"A", ri, ri, 0, +large, 0, xi2, yi2,
-				"L", xo2, yo2,
+				full ? "M" : "L", xo2, yo2,
 				"A", ro, ro, 0, +large, 1, xo1, yo1,
-				"Z",
+				"Z"
 			]);
 		res.middle = {x: xm, y: ym};
 		res.mangle = halfAngle;
@@ -63,8 +68,8 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 
 	function getDataSeriesFromObj(rootLabel, values) {
 		var res = {label: rootLabel, value: 0, children: []},
-			maxDepth = 0;
-		for (var i in values) {
+		    maxDepth = 0;
+		for (var i = 0; i < values.length; i++) {
 			var child;
 			if (~~values[i]) {
 				res.value += values[i];
@@ -96,9 +101,9 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 		prevAngle = prevAngle || (opts.offsetAngle || 0);
 		parentIdx = parentIdx || 0;
 		var startAngle,
-			endAngle = prevAngle,
-			children = data.children,
-			childIdx = 0;
+		    endAngle = prevAngle,
+		    children = data.children,
+		    childIdx = 0;
 		for (var i = 0; i < children.length; i++) {
 			startAngle = endAngle;
 			endAngle += children[i].value / total * 360;
@@ -128,33 +133,33 @@ Raphael.fn.g.sunburst = function(cx, cy, values, opts) {
 			sector: sector,
 			cx: cx,
 			cy: cy,
-            mx: sector.middle.x,
-            my: sector.middle.y,
-            mangle: sector.mangle
+			mx: sector.middle.x,
+			my: sector.middle.y,
+			mangle: sector.mangle
 		};
 	}
 
-    chart.hover = function(fin, fout) {
-        fout = fout || function () {};
-        for (var i = 0; i < series.length; i++)
-            (function (sector) {
-                var o = getCallbackContext(sector);
-                sector.mouseover(function () { fin.call(o); });
-                sector.mouseout(function () { fout.call(o); });
-            })(series[i]);
-        return this;
-    };
+	chart.hover = function(fin, fout) {
+		fout = fout || function () {};
+		for (var i = 0; i < series.length; i++)
+			(function (sector) {
+				var o = getCallbackContext(sector);
+				sector.mouseover(function () { fin.call(o); });
+				sector.mouseout(function () { fout.call(o); });
+			})(series[i]);
+		return this;
+	};
 
-    chart.click = function(f) {
-        for (var i = 0; i < series.length; i++)
-            (function (sector) {
-                var o = getCallbackContext(sector);
-                sector.click(function () { f.call(o); });
-            })(series[i]);
-        return this;
-    };
+	chart.click = function(f) {
+		for (var i = 0; i < series.length; i++)
+			(function (sector) {
+				var o = getCallbackContext(sector);
+				sector.click(function () { f.call(o); });
+			})(series[i]);
+		return this;
+	};
 
-    chart.push(series);
-    chart.series = series;
-    return chart;
+	chart.push(series);
+	chart.series = series;
+	return chart;
 };

--- a/g.venn.js
+++ b/g.venn.js
@@ -1,0 +1,131 @@
+/*!
+ * g.venn 0.1 - 2-area Venn-diagrams
+ * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël 
+ *
+ * Copyright (c)2010 zynamics GmbH (http://zynamics.com)
+ * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+ * license.
+ *
+ * Author: Christian Blichmann <christian.blichmann@zynamics.com>
+ */
+Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
+	opts = opts || {};
+	var paper = this,
+		chart = this.set(),
+		areas = this.set(),
+		intersects = this.set();
+
+	function lensArea(d, overlap) {
+		return 2 * Math.acos(d / 2) - d * Math.sqrt(4 - Math.pow(d, 2)) / 2 -
+			Math.PI * overlap;
+	}
+
+	function dLensArea(d) {
+		return -2 / Math.sqrt(1 - Math.pow(d, 2) / 4) -
+			Math.sqrt(4 - Math.pow(d, 2)) / 2 + d /
+			Math.sqrt(4 - Math.pow(d, 2));
+	}
+
+	var	a0 = values.cardinalities[0],
+		a1 = values.cardinalities[1],
+		aI = values.overlaps[0],
+		r0 = Math.sqrt(a0 / Math.PI), // Get radii for area, unscaled
+		r1 = Math.sqrt(a1 / Math.PI),
+		overlap = aI / a0,
+		dnPrev = 0 - lensArea(0, overlap) / dLensArea(0), dn, // Initial guess
+		d, s;
+
+	// Find a distance d, so that the left circle area, the overlap area and
+	// the right circle area are proportional to the given values using
+	// Newton's method. We need many iterations to draw overlap == 0 correctly.
+	// See http://mathworld.wolfram.com/Circle-CircleIntersection.html for
+	// details on circle-circle-intersection.
+	for (var i = 1; i < 150; i++) {
+		dn = Math.max(dnPrev - lensArea(dnPrev, overlap) / dLensArea(dnPrev),
+			1e-14); // Clamp near zero to draw overlap == a0 correctly
+		dnPrev = dn;
+	}
+
+	// Scale to bounding box
+	s = width <= height ? width / ( dn * r0 + 2 * r1 ) : height / r1 / 2;
+	r0 *= s;
+	r1 *= s;
+	d = Math.max(dn * r0, 0) - r0 + r1;
+
+	// Calculate drawing parameters
+	var	x0 = cx - (r1 - r0 + d) / 2,
+		y0 = cy,
+		x1 = x0 + d,
+		y1 = y0,
+		a = Math.sqrt((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) *
+			( d + r1 + r0)) / d,
+		xi = (Math.pow(d, 2) - Math.pow(r1, 2) + Math.pow(r0, 2)) / (2 * d);
+		yi = a / 2;
+
+	function outline2(large0, sweep0, large1, sweep1) {
+		var res = paper.path([
+    		"M", x0 + xi, y0 - yi,
+    		"A", r0, r0, 0, large0, sweep0, x0 + xi, y0 + yi,
+    		"A", r1, r1, 0, large1, sweep1, x0 + xi, y0 - yi,
+    		"Z"
+    	]);
+		// TODO: Calculate middle x and middle y position
+    	return res;
+	}
+
+	function renderParts(areas, intersects) {
+		Raphael.getColor.reset();
+		function colorAttr(i) {
+			return opts.gradients ? {gradient: opts.gradients[i]} : {
+				fill: opts.colors ? opts.colors[i] : Raphael.getColor()};
+		}
+		areas.push(outline2(~~(xi > 0), 0, 0, 1).attr(colorAttr(0)));
+		areas.push(outline2(~~(xi <= 0), 1, 1, 0).attr(colorAttr(1)));
+		intersects.push(outline2(~~(xi <= 0), 1, 0, 1).attr(colorAttr(2)));
+
+		strokes = {stroke: opts.stroke || "#fff",
+			"stroke-width": opts.strokewidth == null ? 1 : opts.strokewidth};
+		areas.attr(strokes);
+		intersects.attr(strokes);
+	}
+
+	renderParts(areas, intersects);
+
+	function getCallbackContext(set) {
+		return {
+			set: set,
+			cx: cx,
+			cy: cy//,
+//            mx: set.middle.x,
+//            my: set.middle.y,
+		};
+	}
+
+    chart.hover = function(fin, fout) {
+        fout = fout || function () {};
+        function h(set) {
+            var o = getCallbackContext(set);
+            set.mouseover(function () { fin.call(o); });
+            set.mouseout(function () { fout.call(o); });
+        };
+        for (var i = 0; i < areas.length; i++) h(areas[i]);
+        for (var i = 0; i < intersects.length; i++) h(intersects[i]);
+        return this;
+    };
+
+    chart.click = function(f) {
+    	function c(set) {
+            var o = getCallbackContext(set);
+            set.click(function () { f.call(o); });
+        }
+        for (var i = 0; i < areas.length; i++) c(areas[i]);
+        for (var i = 0; i < intersects.length; i++) c(intersects[i]);
+        return this;
+    };
+
+    chart.push(areas);
+    chart.push(intersects);
+    chart.areas = areas;
+    chart.intersects = intersects;
+	return chart;
+};

--- a/g.venn.js
+++ b/g.venn.js
@@ -1,8 +1,8 @@
 /*!
- * g.venn 0.1 - 2-area Venn-diagrams
- * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël 
+ * g.venn 0.2 - 2-area Venn-diagrams
+ * Needs g.Raphael 0.4.1 - Charting library, based on Raphaël
  *
- * Copyright (c)2010 zynamics GmbH (http://zynamics.com)
+ * Copyright (c)2010-2011 zynamics GmbH (http://zynamics.com)
  * Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * license.
  *
@@ -11,9 +11,9 @@
 Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
 	opts = opts || {};
 	var paper = this,
-		chart = this.set(),
-		areas = this.set(),
-		intersects = this.set();
+	    chart = this.set(),
+	    areas = this.set(),
+	    intersects = this.set();
 
 	function lensArea(d, overlap) {
 		return 2 * Math.acos(d / 2) - d * Math.sqrt(4 - Math.pow(d, 2)) / 2 -
@@ -26,14 +26,15 @@ Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
 			Math.sqrt(4 - Math.pow(d, 2));
 	}
 
-	var	a0 = values.cardinalities[0],
-		a1 = values.cardinalities[1],
-		aI = values.overlaps[0],
-		r0 = Math.sqrt(a0 / Math.PI), // Get radii for area, unscaled
-		r1 = Math.sqrt(a1 / Math.PI),
-		overlap = aI / a0,
-		dnPrev = 0 - lensArea(0, overlap) / dLensArea(0), dn, // Initial guess
-		d, s;
+	// TODO: Implement 3-area Venn
+	var a0 = values.cardinalities[0],
+	    a1 = values.cardinalities[1],
+	    aI = values.overlaps[0],
+	    r0 = Math.sqrt(a0 / Math.PI), // Get radii for area, unscaled
+	    r1 = Math.sqrt(a1 / Math.PI),
+	    overlap = aI / a0,
+	    dnPrev = 0 - lensArea(0, overlap) / dLensArea(0), dn, // Initial guess
+	    d, s;
 
 	// Find a distance d, so that the left circle area, the overlap area and
 	// the right circle area are proportional to the given values using
@@ -53,24 +54,24 @@ Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
 	d = Math.max(dn * r0, 0) - r0 + r1;
 
 	// Calculate drawing parameters
-	var	x0 = cx - (r1 - r0 + d) / 2,
-		y0 = cy,
-		x1 = x0 + d,
-		y1 = y0,
-		a = Math.sqrt((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) *
+	var x0 = cx - (r1 - r0 + d) / 2,
+	    y0 = cy,
+	    x1 = x0 + d,
+	    y1 = y0,
+	    a = Math.sqrt((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) *
 			( d + r1 + r0)) / d,
 		xi = (Math.pow(d, 2) - Math.pow(r1, 2) + Math.pow(r0, 2)) / (2 * d);
 		yi = a / 2;
 
 	function outline2(large0, sweep0, large1, sweep1) {
 		var res = paper.path([
-    		"M", x0 + xi, y0 - yi,
-    		"A", r0, r0, 0, large0, sweep0, x0 + xi, y0 + yi,
-    		"A", r1, r1, 0, large1, sweep1, x0 + xi, y0 - yi,
-    		"Z"
-    	]);
+			"M", x0 + xi, y0 - yi,
+			"A", r0, r0, 0, large0, sweep0, x0 + xi, y0 + yi,
+			"A", r1, r1, 0, large1, sweep1, x0 + xi, y0 - yi,
+			"Z"
+		]);
 		// TODO: Calculate middle x and middle y position
-    	return res;
+		return res;
 	}
 
 	function renderParts(areas, intersects) {
@@ -95,37 +96,38 @@ Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
 		return {
 			set: set,
 			cx: cx,
-			cy: cy//,
-//            mx: set.middle.x,
-//            my: set.middle.y,
+			cy: cy,
+//			mx: set.middle.x,
+//			my: set.middle.y,
+			values: values
 		};
 	}
 
-    chart.hover = function(fin, fout) {
-        fout = fout || function () {};
-        function h(set) {
-            var o = getCallbackContext(set);
-            set.mouseover(function () { fin.call(o); });
-            set.mouseout(function () { fout.call(o); });
-        };
-        for (var i = 0; i < areas.length; i++) h(areas[i]);
-        for (var i = 0; i < intersects.length; i++) h(intersects[i]);
-        return this;
-    };
+	chart.hover = function(fin, fout) {
+		fout = fout || function () {};
+		function h(set) {
+			var o = getCallbackContext(set);
+			set.mouseover(function () { fin.call(o); });
+			set.mouseout(function () { fout.call(o); });
+		};
+		for (var i = 0; i < areas.length; i++) h(areas[i]);
+		for (var i = 0; i < intersects.length; i++) h(intersects[i]);
+		return this;
+	};
 
-    chart.click = function(f) {
-    	function c(set) {
-            var o = getCallbackContext(set);
-            set.click(function () { f.call(o); });
-        }
-        for (var i = 0; i < areas.length; i++) c(areas[i]);
-        for (var i = 0; i < intersects.length; i++) c(intersects[i]);
-        return this;
-    };
+	chart.click = function(f) {
+		function c(set) {
+			var o = getCallbackContext(set);
+			set.click(function () { f.call(o); });
+		}
+		for (var i = 0; i < areas.length; i++) c(areas[i]);
+		for (var i = 0; i < intersects.length; i++) c(intersects[i]);
+		return this;
+	};
 
-    chart.push(areas);
-    chart.push(intersects);
-    chart.areas = areas;
-    chart.intersects = intersects;
+	chart.push(areas);
+	chart.push(intersects);
+	chart.areas = areas;
+	chart.intersects = intersects;
 	return chart;
 };

--- a/g.venn.js
+++ b/g.venn.js
@@ -48,7 +48,9 @@ Raphael.fn.g.venn = function(cx, cy, width, height, values, opts) {
 	}
 
 	// Scale to bounding box
-	s = width <= height ? width / ( dn * r0 + 2 * r1 ) : height / r1 / 2;
+	s = width <= height ?
+		width / ( dn * r0 + 2 * r1 ) :
+		height / Math.max(r0, r1) / 2;
 	r0 *= s;
 	r1 *= s;
 	d = Math.max(dn * r0, 0) - r0 + r1;


### PR DESCRIPTION
Hi there,

I have created a new diagram plugin for gRaphaël - 2-area Venn diagrams.
It should basically behave like
    http://code.google.com/apis/chart/docs/gallery/venn_charts.html

for two sets. I may update the chart to include support for 3-areas in the future.

Oh, and it's MIT-licensed, so if you want to include it in gRaphaël, feel free :)

Use like this (include g.raphael.js and g.venn.js):
    //...
    var r = Raphael("area");
    venn = r.g.venn(125, 125, 200, 200, {cardinalities: [10, 20], overlaps: [5]},
        {gradients: ["45-#c00-#f55", "45-#0c0-#5f5", "45-#c00-#5f5"], strokewidth: 2});
    //...

You can also use colors instead of gradients. The diagram also support the
hover and the click event.

That's all, have fun!

Christian Blichmann
