### PR TITLE
Add support for xdim and ydim in options.

### DIFF
--- a/g.line.js
+++ b/g.line.js
@@ -78,10 +78,10 @@ Raphael.fn.g.linechart = function (x, y, width, height, valuesx, valuesy, opts) 
     }
     var allx = Array.prototype.concat.apply([], valuesx),
         ally = Array.prototype.concat.apply([], valuesy),
-        xdim = this.g.snapEnds(Math.min.apply(Math, allx), Math.max.apply(Math, allx), valuesx[0].length - 1),
+        xdim = opts.xdim || this.g.snapEnds(Math.min.apply(Math, allx), Math.max.apply(Math, allx), valuesx[0].length - 1),
         minx = xdim.from,
         maxx = xdim.to,
-        ydim = this.g.snapEnds(Math.min.apply(Math, ally), Math.max.apply(Math, ally), valuesy[0].length - 1),
+        ydim = opts.ydim || this.g.snapEnds(Math.min.apply(Math, ally), Math.max.apply(Math, ally), valuesy[0].length - 1),
         miny = ydim.from,
         maxy = ydim.to,
         kx = (width - gutter * 2) / ((maxx - minx) || 1),


### PR DESCRIPTION
Instead of auto-generating the range based on the input points, allow
specifying the extent directly. In particular, this allows you to ensure
that the y range has zero.

Thanks!

-tim
