### PR TITLE
Fix for: hover on Line charts is completely broken

### DIFF
--- a/g.line.js
+++ b/g.line.js
@@ -146,7 +146,7 @@ Raphael.fn.g.linechart = function (x, y, width, height, valuesx, valuesy, opts) 
         for (var i = 0, ii = valuesx.length; i < ii; i++) {
             Xs = Xs.concat(valuesx[i]);
         }
-        Xs.sort();
+        Xs.sort(function(a, b){return a-b;});
         // remove duplicates
         var Xs2 = [],
             xs = [];


### PR DESCRIPTION
Fixes issue with hover always focusing the same point because of a broken sort.
