### PR TITLE
Defcut in opts, and correct(?) ordering of colors

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -21,6 +21,8 @@
             others = 0,
             cut = 9,
             defcut = true;
+        
+        if(typeof opts.defcut != 'undefined') defcut = opts.defcut;
 
         function sector(cx, cy, r, startAngle, endAngle, fill) {
             var rad = Math.PI / 180,
@@ -90,7 +92,7 @@
                 }
 
                 var path = sector(cx, cy, r, angle, angle -= 360 * values[i] / total);
-                var p = paper.path(opts.init ? ipath : path).attr({ fill: opts.colors && opts.colors[i] || chartinst.colors[i] || "#666", stroke: opts.stroke || "#fff", "stroke-width": (opts.strokewidth == null ? 1 : opts.strokewidth), "stroke-linejoin": "round" });
+                var p = paper.path(opts.init ? ipath : path).attr({ fill: opts.colors && opts.colors[values[i].order] || chartinst.colors[i] || "#666", stroke: opts.stroke || "#fff", "stroke-width": (opts.strokewidth == null ? 1 : opts.strokewidth), "stroke-linejoin": "round" });
 
                 p.value = values[i];
                 p.middle = path.middle;


### PR DESCRIPTION
I propose that you should be able to set defcut in options (had to turn it false in a project where we always wanted to view all values and legends).

And colors now match the legends and values order. Not highest to lowest as before.

´edited title´
