### PR TITLE
piechart with one slice should pull fill color from options first

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -44,7 +44,7 @@
         chart.covers = covers;
 
         if (len == 1) {
-            series.push(paper.circle(cx, cy, r).attr({ fill: chartinst.colors[0], stroke: opts.stroke || "#fff", "stroke-width": opts.strokewidth == null ? 1 : opts.strokewidth }));
+            series.push(paper.circle(cx, cy, r).attr({ fill: opts.colors && opts.colors[0] || chartinst.colors[0], stroke: opts.stroke || "#fff", "stroke-width": opts.strokewidth == null ? 1 : opts.strokewidth }));
             covers.push(paper.circle(cx, cy, r).attr(chartinst.shim));
             total = values[0];
             values[0] = { value: values[0], order: 0, valueOf: function () { return this.value; } };


### PR DESCRIPTION
Quick fix for a small issue (pie chart ignoring fill color option for single-slice charts) ...fix uses same idea as line 93.
