### PR TITLE
Updated g.pie.js: Added matchColors Option

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -90,7 +90,8 @@
                 }
 
                 var path = sector(cx, cy, r, angle, angle -= 360 * values[i] / total);
-                var p = paper.path(opts.init ? ipath : path).attr({ fill: opts.colors && opts.colors[i] || chartinst.colors[i] || "#666", stroke: opts.stroke || "#fff", "stroke-width": (opts.strokewidth == null ? 1 : opts.strokewidth), "stroke-linejoin": "round" });
+                var j = (opts.matchColors && opts.matchColors == true) ? values[i].order : i;
+                var p = paper.path(opts.init ? ipath : path).attr({ fill: opts.colors && opts.colors[j] || chartinst.colors[j] || "#666", stroke: opts.stroke || "#fff", "stroke-width": (opts.strokewidth == null ? 1 : opts.strokewidth), "stroke-linejoin": "round" });
 
                 p.value = values[i];
                 p.middle = path.middle;


### PR DESCRIPTION
When using multiple pie charts on one page its good to have consistent colors across the different charts. The matchColors option assigns the colors based on the order of the values and labels. 

So as long as the same colors are passed for a specific label value, the colors will be consistent across different pie charts. 
