### PR TITLE
Sort x values numerically

### DIFF
--- a/g.line.js
+++ b/g.line.js
@@ -182,7 +182,7 @@
                 Xs = Xs.concat(valuesx[i]);
             }
 
-            Xs.sort();
+            Xs.sort(function(a,b) { return a - b; });
             // remove duplicates
 
             var Xs2 = [],


### PR DESCRIPTION
`[1,2,3,10].sort()` yields `[1,10,2,3]` leading to some strange sort columns if the x values are > 10.
