### PR TITLE
Fix a bug that would cause g.line.js to display an erroneous y-axis

### DIFF
--- a/g.raphael.js
+++ b/g.raphael.js
@@ -782,7 +782,7 @@ Raphael.g = {
         t = round(to * Math.pow(10, i)) / Math.pow(10, i);
 
         if (t < to) {
-            t = round((to + .5) * Math.pow(10, i)) / Math.pow(10, i);
+            t = round((to + d) * Math.pow(10, i)) / Math.pow(10, i);
         }
 
         f = round((from - (i > 0 ? 0 : .5)) * Math.pow(10, i)) / Math.pow(10, i);


### PR DESCRIPTION
Fix a bug that would cause g.line.js to display a y-axis from 0 to .5 when the maximum value is very small (< 0.001). In this case, t < to could equal true which would correct t to larger than .5 which would result in a drawn line that is basically on the x-axis.
