### PR TITLE
Select reasonable values from g.snapEnds()

### DIFF
--- a/g.raphael.js
+++ b/g.raphael.js
@@ -753,40 +753,23 @@ Raphael.g = {
             return {from: f, to: t, power: 0};
         }
 
-        function round(a) {
-            return Math.abs(a - .5) < .25 ? ~~(a) + .5 : Math.round(a);
-        }
-
         var d = (t - f) / steps,
-            r = ~~(d),
-            R = r,
-            i = 0;
+            mag = Math.floor(Math.log(d) / Math.log(10)),
+            magPow = Math.pow(10, mag),
+            magMsd = Math.floor(d / magPow + 0.5);
 
-        if (r) {
-            while (R) {
-                i--;
-                R = ~~(d * Math.pow(10, i)) / Math.pow(10, i);
-            }
+        // promote the MSD to either 1, 2, or 5
+        if (magMsd > 5.0)
+            magMsd = 10.0;
+        else if (magMsd > 2.0)
+            magMsd = 5.0;
+        else if (magMsd > 1.0)
+            magMsd = 2.0;
 
-            i ++;
-        } else {
-            while (!r) {
-                i = i || 1;
-                r = ~~(d * Math.pow(10, i)) / Math.pow(10, i);
-                i++;
-            }
+        var step = magMsd * magPow;
 
-            i && i--;
-        }
+        return { from: f - (f % step), to: t - (-t % step), i: mag }
 
-        t = round(to * Math.pow(10, i)) / Math.pow(10, i);
-
-        if (t < to) {
-            t = round((to + .5) * Math.pow(10, i)) / Math.pow(10, i);
-        }
-
-        f = round((from - (i > 0 ? 0 : .5)) * Math.pow(10, i)) / Math.pow(10, i);
-        return { from: f, to: t, power: i };
     },
 
     axis: function (x, y, length, from, to, steps, orientation, labels, type, dashsize, paper) {


### PR DESCRIPTION
g.raphael seems to select strange values for the axis limits. This commit edits the code for g.snapEnds to make it simpler and pick sane numbers for the axis limits:

Thanks to Drew Noakes and his algorithm posted at http://stackoverflow.com/questions/326679/choosing-an-attractive-linear-scale-for-a-graphs-y-axis, which I adapted into g.snapEnds(). In my case, with a time-series dataset, the values for the axis were being selected outside the timeframe of the data. Therefore, the graph was plotted outside the graph area on both sides of the graph. This algorithm selects axis ends that are outside the dataset, is simple, and likely much faster.
