### PR TITLE
Fixes #166 Big black circle cover original dots when using "hover" with linechart

### DIFF
--- a/g.line.js
+++ b/g.line.js
@@ -269,7 +269,7 @@
                     var X = x + gutter + ((valuesx[i] || valuesx[0])[j] - minx) * kx,
                         nearX = x + gutter + ((valuesx[i] || valuesx[0])[j ? j - 1 : 1] - minx) * kx,
                         Y = y + height - gutter - (valuesy[i][j] - miny) * ky;
-                    f ? (C = {}) : cvrs.push(C = paper.circle(X, Y, Math.abs(nearX - X) / 2).attr({ stroke: "#000", fill: "#000", opacity: 1 }));
+                    f ? (C = {}) : cvrs.push(C = paper.circle(X, Y, Math.abs(nearX - X) / 2).attr({ stroke: "#000", fill: "#000", opacity: 0 }));
                     C.x = X;
                     C.y = Y;
                     C.value = valuesy[i][j];


### PR DESCRIPTION
Chesk also click instead of hover – same bug
