### PR TITLE
Allow users to preserve the order of values for pie charts

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -34,6 +34,7 @@
  o legendothers (string) text that will be used in legend to describe options that are collapsed into 1 slice, because they are too small to render [default `"Others"`]
  o legendmark (string) symbol used as a bullet point in legend that has the same colour as the chart slice [default `"circle"`]
  o legendpos (string) position of the legend on the chart [default `"east"`]. Other options are `"north"`, `"south"`, `"west"`
+ o preserveOrder (boolean) whether or not the values should be left in the order provided [default `false`]
  o }
  **
  = (object) path element of the popup
@@ -95,10 +96,12 @@
                 values[i] = { value: values[i], order: i, valueOf: function () { return this.value; } };
             }
             
-            //values are sorted numerically
-            values.sort(function (a, b) {
-                return b.value - a.value;
-            });
+            if (!opts.preserveOrder) {
+                //values are sorted numerically
+                values.sort(function (a, b) {
+                    return b.value - a.value;
+                });
+            }
             
             for (i = 0; i < len; i++) {
                 if (defcut && values[i] * 100 / total < minPercent) {

--- a/g.pie.js
+++ b/g.pie.js
@@ -101,21 +101,20 @@
                 values.sort(function (a, b) {
                     return b.value - a.value;
                 });
-            }
 
-            for (i = 0; i < len; i++) {
-                if (defcut && values[i] * 100 / total < minPercent) {
-                    if (!opts.preserveValues) {
+
+                for (i = 0; i < len; i++) {
+                    if (defcut && values[i] * 100 / total < minPercent) {
                         cut = i;
+                        defcut = false;
                     }
-                    defcut = false;
-                }
 
-                if (i > cut) {
-                    defcut = false;
-                    values[cut].value += values[i];
-                    values[cut].others = true;
-                    others = values[cut].value;
+                    if (i > cut) {
+                        defcut = false;
+                        values[cut].value += values[i];
+                        values[cut].others = true;
+                        others = values[cut].value;
+                    }
                 }
             }
 

--- a/g.pie.js
+++ b/g.pie.js
@@ -34,14 +34,14 @@
  o legendothers (string) text that will be used in legend to describe options that are collapsed into 1 slice, because they are too small to render [default `"Others"`]
  o legendmark (string) symbol used as a bullet point in legend that has the same colour as the chart slice [default `"circle"`]
  o legendpos (string) position of the legend on the chart [default `"east"`]. Other options are `"north"`, `"south"`, `"west"`
- o preserveOrder (boolean) whether or not the values should be left in the order provided [default `false`]
+ o preserveValues (boolean) whether the values should be left as they are provided, rather than the default behaviour of being sorted and small values collapsed [default `false`]
  o }
  **
  = (object) path element of the popup
  > Usage
  | r.piechart(cx, cy, r, values, opts)
  \*/
- 
+
 (function () {
 
     function Piechart(paper, cx, cy, r, values, opts) {
@@ -95,17 +95,19 @@
                 total += values[i];
                 values[i] = { value: values[i], order: i, valueOf: function () { return this.value; } };
             }
-            
-            if (!opts.preserveOrder) {
+
+            if (!opts.preserveValues) {
                 //values are sorted numerically
                 values.sort(function (a, b) {
                     return b.value - a.value;
                 });
             }
-            
+
             for (i = 0; i < len; i++) {
                 if (defcut && values[i] * 100 / total < minPercent) {
-                    cut = i;
+                    if (!opts.preserveValues) {
+                        cut = i;
+                    }
                     defcut = false;
                 }
 
@@ -285,15 +287,15 @@
 
         return chart;
     };
-    
+
     //inheritance
     var F = function() {};
     F.prototype = Raphael.g;
     Piechart.prototype = new F;
-    
+
     //public
     Raphael.fn.piechart = function(cx, cy, r, values, opts) {
         return new Piechart(this, cx, cy, r, values, opts);
     }
-    
+
 })();

--- a/test/piechart3.html
+++ b/test/piechart3.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>gRaphaël Static Pie Chart</title>
+        <link rel="stylesheet" href="css/demo.css" type="text/css" media="screen" charset="utf-8">
+        <link rel="stylesheet" href="css/demo-print.css" type="text/css" media="print" charset="utf-8">
+        <script src="../raphael-min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="../g.raphael.js" type="text/javascript" charset="utf-8"></script>
+        <script src="../g.pie.js" type="text/javascript" charset="utf-8"></script>
+        <script type="text/javascript" charset="utf-8">
+        window.onload = function () {
+            var colors = ['#F00','#00F', '#0F0' ];
+                values = [30, 0, 10, 40, 20],
+                legend = ["A", "B", "C", "D", "E"],
+                r = Raphael("holder");
+
+            r.text(320, 100, "Interactive Pie Chart Preserving values").attr({ font: "20px 'Fontin Sans', Fontin-Sans, sans-serif" });
+            var pie = r.piechart(320, 240, 100, values, { preserveValues: true, colors: colors, legend: legend });
+        };
+        </script>
+    </head>
+    <body class="raphael" id="g.raphael.dmitry.baranovskiy.com">
+        <div id="holder"></div>
+        <p>
+            Demo of <a href="http://g.raphaeljs.com/">gRaphaël</a> JavaScript library.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
Added an option to the piechart named `preserveOrder` to allow users to preserve the order of the values provided so that the pie section colors are always consistent.

This is a non breaking change as the default value is falsy, whereas https://github.com/DmitryBaranovskiy/g.raphael/pull/176 and #79 will break existing functionality 
