### PR TITLE
Add 'set' type to those where center is used for bounding bubble calcs.

### DIFF
--- a/g.raphael.js
+++ b/g.raphael.js
@@ -30,6 +30,7 @@ Raphael.el.popup = function (dir, size, x, y) {
     if (!paper) return;
 
     switch (this.type) {
+        case 'set':
         case 'text':
         case 'circle':
         case 'ellipse': center = true; break;


### PR DESCRIPTION
If you use a set, using "right" (and one of "up" or "down", can't remember which) doesn't create the bubble around the set correctly. Adding set into the list of types that have a centre fixes this.
