### PR TITLE
Add missing semicolon to last line

### DIFF
--- a/g.raphael.js
+++ b/g.raphael.js
@@ -858,4 +858,4 @@ Raphael.g = {
             return (+val).toFixed(0);
         }
     }
-}
+};


### PR DESCRIPTION
Missing semicolon in the end of the chart prototype declaration, which can create problems when concatenating this file with others
