### PR TITLE
bugfix: loop through colors if less colors than bars

### DIFF
--- a/g.bar.js
+++ b/g.bar.js
@@ -236,7 +236,7 @@
             for (var j = 0; j < (multi || 1); j++) {
                 var h = Math.round((multi ? values[j][i] : values[i]) * Y),
                     top = y + height - barvgutter - h,
-                    bar = finger(Math.round(X + barwidth / 2), top + h, barwidth, h, true, type, null, paper).attr({ stroke: "none", fill: colors[multi ? j : i] });
+                    bar = finger(Math.round(X + barwidth / 2), top + h, barwidth, h, true, type, null, paper).attr({ stroke: "none", fill: colors[ (multi ? j : i) % colors.length ] });
 
                 if (multi) {
                     bars[j].push(bar);


### PR DESCRIPTION
without this fix, a bar-chart having more bars than colors does only show colors.length bars, the rest of the bars are invisible. Using this approach, the remaining bars start to reuse already used colors.
