### PR TITLE
Update g.raphael.js - add semicolon

### DIFF
--- a/g.raphael.js
+++ b/g.raphael.js
@@ -858,4 +858,4 @@ Raphael.g = {
             return (+val).toFixed(0);
         }
     }
-}
+};


### PR DESCRIPTION
In my company we are merging several files into one. g.raphael.js comes immediately before g.line.js. Trying to evaluate the resulting file shows "TypeError: object is not a function" because first code line of g.line.js starts with "(". So the browser (at least current Chrome) tries to evaluate that together showing an error (of course). We did a monkey patch using ";" at the end of g.raphael.js (which anyway makes sense to end that code line) and do not experience problems any more.

Summarized code excerpt:
(last object setup in g.raphael.js)
//chart prototype for storing common functions
Raphael.g = {
  //...
}

(start of g.line.js)
/*!
- g.Raphael 0.51 - Charting library, based on Raphaël
  *
- Copyright (c) 2009-2012 Dmitry Baranovskiy (http://g.raphaeljs.com)
- Licensed under the MIT (http://www.opensource.org/licenses/mit-license.php) license.
  */

(function () {

=> so the browser tried to somehow eval "Raphael.g = {}(function() {" when we concatenated the files. At least that is the only thing I can imagine.

Cheers,
Tobias Krogh
