### PR TITLE
Fixes href sort order for pie charts

### DIFF
--- a/g.pie.js
+++ b/g.pie.js
@@ -142,8 +142,9 @@
             }
 
             for (i = 0; i < len; i++) {
+                j = values[i].order;
                 p = paper.path(sectors[i].attr("path")).attr(chartinst.shim);
-                opts.href && opts.href[i] && p.attr({ href: opts.href[i] });
+                opts.href && opts.href[j] && p.attr({ href: opts.href[j] });
                 p.attr = function () {};
                 covers.push(p);
                 series.push(p);


### PR DESCRIPTION
Fixes #88

I realize this is unlikely to ever get pulled, but I ran into an old project that relied on g.raphael and experienced this bug.  In case anyone else might benefit from this...
